### PR TITLE
Fixes #5: updates README, adds default auth for localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ $ ./udpt -d [udpt.log] [udpt.conf]
 Cleaning:
 $ make clean
 
+Adding torrent using HTTP API:
+https://127.0.0.1?auth=admin&action=add&hash=TORRENT_HASH
+you can change the ip and auth value in udpt.conf file under [api.keys]
+
 This software currently uses the Sqlite3 Library (public domain).
 
 Developed by Naim A. <naim94a@gmail.com>.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,7 @@ int main(int argc, char *argv[])
 		const char strDATABASE[] = "database";
 		const char strTRACKER[] = "tracker";
 		const char strAPISRV [] = "apiserver";
+		const char strAPIKEY [] = "api.keys";
 		// set default settings:
 
 		settings->set (strDATABASE, "driver", "sqlite3");
@@ -162,6 +163,9 @@ int main(int argc, char *argv[])
 		settings->set (strAPISRV, "enable", "1");
 		settings->set (strAPISRV, "threads", "1");
 		settings->set (strAPISRV, "port", "6969");	// TCP PORT
+
+		settings->set(strAPIKEY, "admin", "127.0.0.1");
+
 
 		settings->save();
 		cerr << "Failed to read from '" << config_file.c_str() << "'. Using default settings." << endl;


### PR DESCRIPTION
Mentioned HTTP API in README and added a default auth parameter "admin" for 127.0.0.1 